### PR TITLE
Config for producer can be passed as key value pairs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,7 @@
                             <configuration>
                                 <sourceDirs>
                                     <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                    <sourceDir>${project.basedir}/src/main/java</sourceDir>
                                 </sourceDirs>
                             </configuration>
                         </execution>

--- a/spring-pulsar-core/src/main/kotlin/com/intuit/spring/pulsar/client/config/PulsarConfigKey.kt
+++ b/spring-pulsar-core/src/main/kotlin/com/intuit/spring/pulsar/client/config/PulsarConfigKey.kt
@@ -1,0 +1,18 @@
+package com.intuit.spring.pulsar.client.config
+
+object PulsarConfigKey {
+    const val TOPIC_NAME: String = "topicName"
+    const val PRODUCER_NAME: String = "producerName"
+    const val SEND_TIMEOUT: String = "sendTimeout"
+    const val BLOCK_IF_QUEUE_FULL:  String = "blockIfQueueFull"
+    const val CRYPTO_FAILURE_ACTION: String = "cryptoFailureAction"
+    const val AUTO_FLUSH: String = "autoFlush"
+    const val BATCHING_MAX_PUBLISH_DELAY_MICROS: String = "batchingMaxPublishDelayMicros"
+    const val BATCHING_MAX_MESSAGES: String = "batchingMaxMessages"
+    const val BATCHING_ENABLED: String = "batchingEnabled"
+    const val MAX_PENDING_MESSAGES: String = "maxPendingMessages"
+    const val MAX_PENDING_MESSAGES_ACROSS_PARTITIONS: String = "maxPendingMessagesAcrossPartitions"
+    const val MESSAGE_ROUTING_MODE: String = "messageRoutingMode"
+    const val HASHING_SCHEME: String = "hashingScheme"
+    const val COMPRESSION_TYPE: String = "compressionType"
+}

--- a/spring-pulsar-core/src/main/kotlin/com/intuit/spring/pulsar/client/config/PulsarProducerConfigMapper.kt
+++ b/spring-pulsar-core/src/main/kotlin/com/intuit/spring/pulsar/client/config/PulsarProducerConfigMapper.kt
@@ -1,0 +1,85 @@
+package com.intuit.spring.pulsar.client.config
+
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.AUTO_FLUSH
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.BATCHING_ENABLED
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.BATCHING_MAX_MESSAGES
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.BATCHING_MAX_PUBLISH_DELAY_MICROS
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.BLOCK_IF_QUEUE_FULL
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.COMPRESSION_TYPE
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.CRYPTO_FAILURE_ACTION
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.HASHING_SCHEME
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.MAX_PENDING_MESSAGES
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.MAX_PENDING_MESSAGES_ACROSS_PARTITIONS
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.MESSAGE_ROUTING_MODE
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.PRODUCER_NAME
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.SEND_TIMEOUT
+import org.apache.pulsar.client.api.Schema
+import java.time.Duration
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.TOPIC_NAME
+import org.apache.pulsar.client.api.CompressionType
+import org.apache.pulsar.client.api.HashingScheme
+import org.apache.pulsar.client.api.MessageRoutingMode
+import org.apache.pulsar.client.api.ProducerCryptoFailureAction
+
+/**
+ * Config mapping class to map producer config
+ * map into [PulsarProducerConfig] object.
+ */
+class PulsarProducerConfigMapper<T> {
+
+    /**
+     * Creates [PulsarProducerConfig] object
+     * from config map passes as argument.
+     * @param config: [MutableMap]
+     * @param schema: [Schema]
+     * @return [PulsarProducerConfig]
+     */
+    fun map(
+        config: MutableMap<String, String>,
+        schema: Schema<T>
+    ): PulsarProducerConfig<T> {
+        return PulsarProducerConfig(
+            schema = schema,
+            topicName = config[TOPIC_NAME]!!,
+            name = config[PRODUCER_NAME],
+            sendTimeout = config[SEND_TIMEOUT]?.let { Duration.ofMillis(config[SEND_TIMEOUT]!!.toLong()) },
+            blockIfQueueFull = config[BLOCK_IF_QUEUE_FULL]?.toBoolean(),
+            cryptoFailureAction = config[CRYPTO_FAILURE_ACTION]?.let {
+                ProducerCryptoFailureAction.valueOf(config[CRYPTO_FAILURE_ACTION]!!) },
+            autoFlush = config[AUTO_FLUSH]?.toBoolean() ?: true,
+            message = mapMessageConfig(config),
+            batch = mapBatchingConfig(config)
+        )
+    }
+
+    /**
+     * Creates [PulsarProducerBatchingConfig] object
+     * from config map passes as argument.
+     * @param config: [MutableMap]
+     * @return [PulsarProducerBatchingConfig]
+     */
+    private fun mapBatchingConfig(config: MutableMap<String, String>): PulsarProducerBatchingConfig {
+        return PulsarProducerBatchingConfig(
+            batchingEnabled = config[BATCHING_ENABLED]?.toBoolean(),
+            batchingMaxMessages = config[BATCHING_MAX_MESSAGES]?.toInt(),
+            batchingMaxPublishDelayMicros = config[BATCHING_MAX_PUBLISH_DELAY_MICROS]?.toLong()
+        )
+    }
+
+    /**
+     * Creates [PulsarProducerMessageConfig] object
+     * from config map passes as argument.
+     * @param config: [MutableMap]
+     * @return [PulsarProducerMessageConfig]
+     */
+    private fun mapMessageConfig(config: MutableMap<String, String>): PulsarProducerMessageConfig {
+        return PulsarProducerMessageConfig(
+            maxPendingMessages = config[MAX_PENDING_MESSAGES]?.toInt(),
+            maxPendingMessagesAcrossPartitions = config[MAX_PENDING_MESSAGES_ACROSS_PARTITIONS]?.toInt(),
+            messageRoutingMode = config[MESSAGE_ROUTING_MODE]?.let {
+                MessageRoutingMode.valueOf(config[MESSAGE_ROUTING_MODE]!!) },
+            hashingScheme = config[HASHING_SCHEME]?.let { HashingScheme.valueOf(config[HASHING_SCHEME]!!) },
+            compressionType = config[COMPRESSION_TYPE]?.let { CompressionType.valueOf(config[COMPRESSION_TYPE]!!) }
+        )
+    }
+}

--- a/spring-pulsar-core/src/main/kotlin/com/intuit/spring/pulsar/client/template/PulsarProducerTemplateImpl.kt
+++ b/spring-pulsar-core/src/main/kotlin/com/intuit/spring/pulsar/client/template/PulsarProducerTemplateImpl.kt
@@ -2,12 +2,14 @@ package com.intuit.spring.pulsar.client.template
 
 import com.intuit.spring.pulsar.client.client.PulsarClientFactory
 import com.intuit.spring.pulsar.client.config.PulsarProducerConfig
+import com.intuit.spring.pulsar.client.config.PulsarProducerConfigMapper
 import com.intuit.spring.pulsar.client.producer.IPulsarProducerMessageFactory
 import com.intuit.spring.pulsar.client.producer.PulsarProducer
 import com.intuit.spring.pulsar.client.producer.PulsarProducerFactory
 import com.intuit.spring.pulsar.client.producer.PulsarProducerMessageFactory
 import org.apache.pulsar.client.api.MessageId
 import org.apache.pulsar.client.api.ProducerStats
+import org.apache.pulsar.client.api.Schema
 import org.springframework.context.ApplicationContext
 import org.springframework.util.concurrent.ListenableFutureCallback
 import java.util.concurrent.CompletableFuture
@@ -20,8 +22,18 @@ import java.util.concurrent.CompletableFuture
 @Suppress("TooManyFunctions")
 class PulsarProducerTemplateImpl<T>(
     pulsarProducerConfig: PulsarProducerConfig<T>,
-    applicationContext: ApplicationContext
+    applicationContext: ApplicationContext,
 ) : PulsarProducerTemplate<T> {
+
+    constructor(
+        schema: Schema<T>,
+        config: MutableMap<String, String>,
+        applicationContext: ApplicationContext
+    ) :
+            this(
+                PulsarProducerConfigMapper<T>().map(schema = schema, config = config),
+                applicationContext
+            )
 
     private val producer: PulsarProducer<T> = PulsarProducerFactory(
         pulsarProducerConfig,

--- a/spring-pulsar-core/src/test/kotlin/com/intuit/spring/pulsar/client/config/PulsarProducerConfigMapperTest.kt
+++ b/spring-pulsar-core/src/test/kotlin/com/intuit/spring/pulsar/client/config/PulsarProducerConfigMapperTest.kt
@@ -1,0 +1,89 @@
+package com.intuit.spring.pulsar.client.config
+
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.AUTO_FLUSH
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.BATCHING_ENABLED
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.BATCHING_MAX_MESSAGES
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.BATCHING_MAX_PUBLISH_DELAY_MICROS
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.BLOCK_IF_QUEUE_FULL
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.COMPRESSION_TYPE
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.CRYPTO_FAILURE_ACTION
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.HASHING_SCHEME
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.MAX_PENDING_MESSAGES
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.MAX_PENDING_MESSAGES_ACROSS_PARTITIONS
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.MESSAGE_ROUTING_MODE
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.PRODUCER_NAME
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.SEND_TIMEOUT
+import org.junit.jupiter.api.Test
+import com.intuit.spring.pulsar.client.config.PulsarConfigKey.TOPIC_NAME
+import org.apache.pulsar.client.api.*
+import org.junit.jupiter.api.Assertions.*
+
+
+class PulsarProducerConfigMapperTest {
+
+    private val configMapper = PulsarProducerConfigMapper<ByteArray>()
+
+    @Test
+    fun `create producer config with all properties set`() {
+        val config = mutableMapOf(
+            TOPIC_NAME to "test-topic",
+            PRODUCER_NAME to "test-producer",
+            SEND_TIMEOUT to "10000",
+            BLOCK_IF_QUEUE_FULL to "true",
+            CRYPTO_FAILURE_ACTION to ProducerCryptoFailureAction.FAIL.name,
+            AUTO_FLUSH to "false",
+            BATCHING_ENABLED to "true",
+            BATCHING_MAX_MESSAGES to "100",
+            BATCHING_MAX_PUBLISH_DELAY_MICROS to "1000",
+            MAX_PENDING_MESSAGES to "100",
+            MAX_PENDING_MESSAGES_ACROSS_PARTITIONS to "100",
+            HASHING_SCHEME to HashingScheme.JavaStringHash.name,
+            COMPRESSION_TYPE to CompressionType.ZLIB.name,
+            MESSAGE_ROUTING_MODE to MessageRoutingMode.RoundRobinPartition.name
+        )
+
+        val producerConfig = configMapper.map(config, Schema.BYTES)
+
+        assertEquals(Schema.BYTES,producerConfig.schema)
+        assertEquals("test-topic",producerConfig.topicName)
+        assertEquals("test-producer",producerConfig.name)
+        assertEquals(10000, producerConfig.sendTimeout!!.toMillis())
+        assertTrue(producerConfig.blockIfQueueFull!!)
+        assertEquals(ProducerCryptoFailureAction.FAIL,producerConfig.cryptoFailureAction)
+        assertFalse(producerConfig.autoFlush)
+        assertTrue(producerConfig.batch.batchingEnabled!!)
+        assertEquals(100,producerConfig.batch.batchingMaxMessages)
+        assertEquals(1000,producerConfig.batch.batchingMaxPublishDelayMicros)
+        assertEquals(100,producerConfig.message.maxPendingMessages)
+        assertEquals(100,producerConfig.message.maxPendingMessagesAcrossPartitions)
+        assertEquals(HashingScheme.JavaStringHash,producerConfig.message.hashingScheme)
+        assertEquals(CompressionType.ZLIB,producerConfig.message.compressionType)
+        assertEquals(MessageRoutingMode.RoundRobinPartition,producerConfig.message.messageRoutingMode)
+    }
+
+    @Test
+    fun `create producer config with only mandatory properties set`() {
+        val config = mutableMapOf(
+            TOPIC_NAME to "test-topic"
+        )
+
+        val producerConfig = configMapper.map(config, Schema.BYTES)
+
+        assertEquals(Schema.BYTES,producerConfig.schema)
+        assertEquals("test-topic",producerConfig.topicName)
+        assertNull(producerConfig.name)
+        assertNull(producerConfig.sendTimeout)
+        assertNull(producerConfig.blockIfQueueFull)
+        assertNull(producerConfig.cryptoFailureAction)
+        assertTrue(producerConfig.autoFlush)
+        assertNull(producerConfig.batch.batchingEnabled)
+        assertNull(producerConfig.batch.batchingMaxMessages)
+        assertNull(producerConfig.batch.batchingMaxPublishDelayMicros)
+        assertNull(producerConfig.message.maxPendingMessages)
+        assertNull(producerConfig.message.maxPendingMessagesAcrossPartitions)
+        assertNull(producerConfig.message.hashingScheme)
+        assertNull(producerConfig.message.compressionType)
+        assertNull(producerConfig.message.messageRoutingMode)
+    }
+
+}

--- a/spring-pulsar-samples/java-sample/src/main/java/com/intuit/spring/pulsar/java/sample01/ProducerConfiguration.java
+++ b/spring-pulsar-samples/java-sample/src/main/java/com/intuit/spring/pulsar/java/sample01/ProducerConfiguration.java
@@ -1,8 +1,6 @@
 package com.intuit.spring.pulsar.java.sample01;
 
-import com.intuit.spring.pulsar.client.config.PulsarProducerBatchingConfig;
-import com.intuit.spring.pulsar.client.config.PulsarProducerConfig;
-import com.intuit.spring.pulsar.client.config.PulsarProducerMessageConfig;
+
 import com.intuit.spring.pulsar.client.template.PulsarProducerTemplate;
 import com.intuit.spring.pulsar.client.template.PulsarProducerTemplateImpl;
 import org.apache.pulsar.client.api.Schema;
@@ -10,6 +8,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.intuit.spring.pulsar.client.config.PulsarConfigKey.AUTO_FLUSH;
+import static com.intuit.spring.pulsar.client.config.PulsarConfigKey.TOPIC_NAME;
 
 @Configuration("producerConf01")
 public class ProducerConfiguration {
@@ -25,17 +28,14 @@ public class ProducerConfiguration {
 
     @Bean
     public PulsarProducerTemplate producerTemplate01() {
+        Map<String,String> config = new HashMap<>();
+        config.put(TOPIC_NAME,topicName);
+        config.put(AUTO_FLUSH,"true");
+
         return new PulsarProducerTemplateImpl(
-                new PulsarProducerConfig(
-                        Schema.BYTES,
-                        topicName,
-                        null,
-                        null,
-                        null,
-                        null,
-                        new PulsarProducerMessageConfig(),
-                        new PulsarProducerBatchingConfig(),
-                        true),
-                applicationContext);
+                Schema.BYTES,
+                config,
+                applicationContext
+        );
     }
 }

--- a/spring-pulsar-samples/java-sample/src/main/java/com/intuit/spring/pulsar/java/sample02/ProducerConfiguration.java
+++ b/spring-pulsar-samples/java-sample/src/main/java/com/intuit/spring/pulsar/java/sample02/ProducerConfiguration.java
@@ -1,8 +1,5 @@
 package com.intuit.spring.pulsar.java.sample02;
 
-import com.intuit.spring.pulsar.client.config.PulsarProducerBatchingConfig;
-import com.intuit.spring.pulsar.client.config.PulsarProducerConfig;
-import com.intuit.spring.pulsar.client.config.PulsarProducerMessageConfig;
 import com.intuit.spring.pulsar.client.template.PulsarProducerTemplate;
 import com.intuit.spring.pulsar.client.template.PulsarProducerTemplateImpl;
 import org.apache.pulsar.client.api.Schema;
@@ -10,6 +7,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.intuit.spring.pulsar.client.config.PulsarConfigKey.AUTO_FLUSH;
+import static com.intuit.spring.pulsar.client.config.PulsarConfigKey.TOPIC_NAME;
 
 @Configuration("producerConf02")
 public class ProducerConfiguration {
@@ -25,17 +28,14 @@ public class ProducerConfiguration {
 
     @Bean
     public PulsarProducerTemplate producerTemplate02() {
+        Map<String,String> config = new HashMap<>();
+        config.put(TOPIC_NAME,topicName);
+        config.put(AUTO_FLUSH,"true");
+
         return new PulsarProducerTemplateImpl(
-                new PulsarProducerConfig(
-                        Schema.BYTES,
-                        topicName,
-                        null,
-                        null,
-                        null,
-                        null,
-                        new PulsarProducerMessageConfig(),
-                        new PulsarProducerBatchingConfig(),
-                        true),
-                applicationContext);
+                Schema.BYTES,
+                config,
+                applicationContext
+        );
     }
 }


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](../CONTRIBUTING.md).

- [x] I've read and agree to the project's contribution guidelines.
- [x] I'm requesting to **pull a topic/feature/bugfix branch**.
- [x] I checked that my code additions will pass code linting checks and unit tests.
- [x] I updated unit tests (if applicable).
- [x] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?
It defines new constructor in producer template to pass producer configuration as a map of configuration key and value pairs. This allows easier creation of producer template by java based application.

In this change we are define a mapper to map configs passed as key value pair to PulsarProducerConfig object.

Thank you!
