### PR TITLE
Execute gpg source and dokka plugin on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
                     <version>${dokka.version}</version>
                     <executions>
                         <execution>
-                            <phase>package</phase>
+                            <phase>deploy</phase>
                             <goals>
                                 <goal>javadocJar</goal>
                             </goals>
@@ -362,7 +362,7 @@
                     <executions>
                         <execution>
                             <id>attach-sources</id>
-                            <phase>package</phase>
+                            <phase>deploy</phase>
                             <goals>
                                 <goal>jar</goal>
                             </goals>
@@ -393,7 +393,7 @@
                     <executions>
                         <execution>
                             <id>sign-artifacts</id>
-                            <phase>verify</phase>
+                            <phase>deploy</phase>
                             <goals>
                                 <goal>sign</goal>
                             </goals>


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](../CONTRIBUTING.md).

- [x] I've read and agree to the project's contribution guidelines.
- [x] I'm requesting to **pull a topic/feature/bugfix branch**.
- [x] I checked that my code additions will pass code linting checks and unit tests.
- [x] I updated unit tests (if applicable).
- [x] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?
As of now gpg,  dokka and source plugin are execute in normal builds. This causes slow build during developement and adds a dependency on developers to setup gpg and other configuration in their local machine. This is nor required for normal developement process.

We need to run these plugins only when a release is triggerd as the artifact generated by these plugins are used in release process. Hence disabling execution of these plugin in normal maven build and executing it only on maven deploy command execution.

Thank you!
