### PR TITLE
Use maven release plugin for nexus release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: mvn --no-transfer-progress --batch-mode -Dgpg.passphrase=${{ secrets.OSSRH_GPG_PASSPHRASE }} clean deploy -f spring-pulsar-core/pom.xml
+        run: mvn -Darguments="-Dgpg.passphrase=${{ secrets.OSSRH_GPG_PASSPHRASE}}" -DautoVersionSubmodules=true  release:clean release:prepare release:perform
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <dokka.version>1.7.20</dokka.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -388,8 +389,23 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>${maven-release-plugin.version}</version>
+                    <configuration>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <goals>deploy</goals>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
+    <scm>
+        <connection>scm:git:git://github.com/intuit/spring-pulsar.git</connection>
+        <developerConnection>scm:git:ssh://github.com:intuit/spring-pulsar.git</developerConnection>
+        <url>https://github.com/intuit/spring-pulsar</url>
+    </scm>
+    
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,7 @@
                     <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <tagNameFormat>v@{project.version}</tagNameFormat>
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](../CONTRIBUTING.md).

- [x] I've read and agree to the project's contribution guidelines.
- [x] I'm requesting to **pull a topic/feature/bugfix branch**.
- [x] I checked that my code additions will pass code linting checks and unit tests.
- [x] I updated unit tests (if applicable).
- [x] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

As of now release is done by maven deploy phase invocation. Because of this with each release we will have to do manual code change for version update before release and version update after release. This whole process can be automated using mave-release-plugin.

With this change we are using maven-release-plugin to do nexus release.This helps us by autmating release version updates and commit to repo.

Thank you!
