### PR TITLE
Execute gpg plugin when sign-artifact profile is activated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: mvn --no-transfer-progress --batch-mode -Dgpg.passphrase=${{ secrets.OSSRH_GPG_PASSPHRASE }} clean deploy -f spring-pulsar-core/pom.xml
+        run: mvn --no-transfer-progress --batch-mode -Dgpg.passphrase=${{ secrets.OSSRH_GPG_PASSPHRASE }} clean deploy -f spring-pulsar-core/pom.xml -P sign-artifact
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/spring-pulsar-core/pom.xml
+++ b/spring-pulsar-core/pom.xml
@@ -199,10 +199,19 @@
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>sign-artifact</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](../CONTRIBUTING.md).

- [x] I've read and agree to the project's contribution guidelines.
- [x] I'm requesting to **pull a topic/feature/bugfix branch**.
- [x] I checked that my code additions will pass code linting checks and unit tests.
- [x] I updated unit tests (if applicable).
- [x] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?
Right now when developer runs `mvn clean install` , maven also executes maven-gpg-plugin , which fails if the developer has not setup gpg plugin in local. 

Ideally for developement such setup is not required and signing of artifact has to be done only on release.

So added a gpg plusing execution inside a profile, so that developers dont have to worry about gpg plugins in developement time.

Thank you!
